### PR TITLE
Add support for lerna using yarn workspaces

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -27,11 +27,19 @@ export class LernaPackagesPlugin extends ConverterComponent {
         super(owner);
 
         const lernaConfig = JSON.parse(fs.readFileSync('lerna.json', 'utf8'));
-        if (!lernaConfig.packages) {
+        let packages: string[] = [];
+        if (lernaConfig.packages) {
+            packages = lernaConfig.packages;
+        } else if (lernaConfig.useWorkspaces) {
+            const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            packages = packageJson.workspaces;
+        }
+
+        if (!packages || packages.length === 0) {
             throw new Error('No lerna.json found or packages defined.');
         }
 
-        for (const packageGlob of lernaConfig['packages']) {
+        for (const packageGlob of packages) {
             const thisPkgs = glob.sync(packageGlob, {
                 ignore: ['node_modules']
             });
@@ -138,4 +146,3 @@ export class LernaPackagesPlugin extends ConverterComponent {
         }
     }
 }
-


### PR DESCRIPTION
Lerna repos using yarn workspaces have the package globs defined in the `package.json` instead of the `lerna.json`. This just adds a check for the `useWorkspaces` key.

See [lerna docs](https://github.com/lerna/lerna/tree/master/commands/bootstrap#--use-workspaces) regarding yarn workspaces.