### PR TITLE
Normalize paths for comparison

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -73,8 +73,8 @@ export class LernaPackagesPlugin extends ConverterComponent {
             for (const i in this.lernaPackages) {
                 if (!this.lernaPackages.hasOwnProperty(i)) continue;
 
-                const packagePath = normalize(join(cwd, this.lernaPackages[i]) + '/');
-                if (-1 !== normalize(path + '/').indexOf(packagePath)) {
+                const packagePath = join(cwd, this.lernaPackages[i]) + '/';
+                if (-1 !== normalize(path + '/').indexOf(normalize(packagePath))) {
                     if (i.length > fit.length) {
                         fit = i;
                     }

--- a/plugin.ts
+++ b/plugin.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as glob from 'glob';
-import { join } from "path";
+import { join, normalize } from "path";
 import { DeclarationReflection } from "typedoc";
 import { Component, ConverterComponent } from "typedoc/dist/lib/converter/components";
 import { Context } from "typedoc/dist/lib/converter/context";
@@ -73,8 +73,8 @@ export class LernaPackagesPlugin extends ConverterComponent {
             for (const i in this.lernaPackages) {
                 if (!this.lernaPackages.hasOwnProperty(i)) continue;
 
-                const packagePath = join(cwd, this.lernaPackages[i]) + '/';
-                if (-1 !== (path + '/').indexOf(packagePath)) {
+                const packagePath = normalize(join(cwd, this.lernaPackages[i]) + '/');
+                if (-1 !== normalize(path + '/').indexOf(packagePath)) {
                     if (i.length > fit.length) {
                         fit = i;
                     }


### PR DESCRIPTION
Avoids path separator mix ups

My issue was that when using Windows, path separators / and \ were mixed in the built package path, so the path was not matching the module path correctly. Normalizing the paths make it work like a charm.

```
$ node_modules/.bin/typedoc .
Loaded plugin C:\herberttn\workspace\heimdall\node_modules\typedoc-plugin-lerna-packages

Using TypeScript 3.2.4 from C:\herberttn\workspace\heimdall\node_modules\typedoc\node_modules\typescript\lib
Lerna packages found {
  '@herberttn/heimdall-default-browser-module': 'modules/browser',
  '@herberttn/heimdall-application': 'packages/application',
  '@herberttn/heimdall-builder': 'packages/builder',
  '@herberttn/heimdall-core': 'packages/core',
  '@herberttn/heimdall-utils': 'packages/utils'
}
C:\herberttn\workspace\heimdall\node_modules\typedoc-plugin-lerna-packages\plugin.js:70
                throw new Error(`No lerna package found for ${path}`);
                ^

Error: No lerna package found for C:/herberttn/workspace/heimdall/modules/browser/src/index.ts
    at findLernaPackageForChildOriginalName (C:\herberttn\workspace\heimdall\node_modules\typedoc-plugin-lerna-packages\plugin.js:70:23)
    at LernaPackagesPlugin.onBeginResolve (C:\herberttn\workspace\heimdall\node_modules\typedoc-plugin-lerna-packages\plugin.js:94:38)
    at triggerEvents (C:\herberttn\workspace\heimdall\node_modules\typedoc\dist\lib\utils\events.js:128:43)
    at triggerApi (C:\herberttn\workspace\heimdall\node_modules\typedoc\dist\lib\utils\events.js:110:13)
    at eventsApi (C:\herberttn\workspace\heimdall\node_modules\typedoc\dist\lib\utils\events.js:21:18)
    at Converter.trigger (C:\herberttn\workspace\heimdall\node_modules\typedoc\dist\lib\utils\events.js:264:13)
    at Converter.resolve (C:\herberttn\workspace\heimdall\node_modules\typedoc\dist\lib\converter\converter.js:173:14)
    at Converter.convert (C:\herberttn\workspace\heimdall\node_modules\typedoc\dist\lib\converter\converter.js:96:30)
    at CliApplication.convert (C:\herberttn\workspace\heimdall\node_modules\typedoc\dist\lib\application.js:61:39)
    at CliApplication.bootstrap (C:\herberttn\workspace\heimdall\node_modules\typedoc\dist\lib\cli.js:44:34)
```