### PR TITLE
feat: pathExclude option - Exclude entire paths

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -19,7 +19,15 @@ export class LernaPackagesPlugin extends ConverterComponent {
         type: ParameterType.Array,
         defaultValue: []
     })
-    exclude!: string[];
+    lernaExclude!: string[];
+
+    @Option({
+      name: 'pathExclude',
+      help: 'List of paths to entirely ignore',
+      type: ParameterType.Array,
+      defaultValue: []
+    })
+    pathExclude!: string[];
 
     private lernaPackages: { [name: string]: string } = {};
 
@@ -112,8 +120,8 @@ export class LernaPackagesPlugin extends ConverterComponent {
         }
 
         for (const child of copyChildren) {
+            if(this.pathExclude.some(pkg => child.originalName.includes(pkg))) continue;
             const lernaPackageName = findLernaPackageForChildOriginalName(child.originalName);
-
 
             if (!lernaPackageModules[lernaPackageName]) {
                 throw new Error(`lerna package module for ${lernaPackageName} not found.`);
@@ -135,7 +143,7 @@ export class LernaPackagesPlugin extends ConverterComponent {
         }
 
         for (const i in lernaPackageModules) {
-            if (-1 !== this.exclude.indexOf(i)) {
+            if (-1 !== this.lernaExclude.indexOf(i)) {
                 continue;
             }
 


### PR DESCRIPTION
This option will completely exclude given paths. This can be used when having *.ts files *included* in the TS configuration, but which should be *excluded* from the documentation. A great example of this is when you have a "scripts" folder in root.

You can see how I applied this change in my repo: https://github.com/favware/node-packages/tree/wip/move-to-typedoc. Specifically see [`tsconfig.json`](https://github.com/favware/node-packages/blob/wip/move-to-typedoc/tsconfig.json). Running `yarn docs` will now work rather than throwing due to `scripts` not being in a lerna package path, and ultimatetly a good TypeDoc page gets generated:
![image](https://user-images.githubusercontent.com/4019718/64693255-2789c000-d497-11e9-8b35-e5d35dd76d63.png)


(note: rebased with the just merged PR so I'm all up to date here)