### PR TITLE
fix: fixes an issue where additional file entries were in the docs

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -130,7 +130,12 @@ export class LernaPackagesPlugin extends ConverterComponent {
             // console.log('lernaPackageModules[lernaPackageName]', lernaPackageModules[lernaPackageName]);
             if (child.kindOf(ReflectionKind.ExternalModule) || child.kindOf(ReflectionKind.Module)) {
                 console.log(`put ${child.name} stuff into ${lernaPackageName}`);
-                const projectFileEntry = Object.entries(context.project.reflections).find(([key,value]) => value.name === child.name ? key : null);
+                /* This will search through the project level reflections collection to find an entry with the 
+                 * same name as the child we are currently working with so that it can be removed. 
+                 * This prevents it from appearing on the main index page but is still visible within the module
+                */
+                const projectFileEntry = Object.entries(context.project.reflections)
+                    .find(([key,value]) => value.name === child.name ? key : null);
                 delete context.project.reflections[projectFileEntry[0]];
                 if (child.children) {
                     for (const cc of child.children) {

--- a/plugin.ts
+++ b/plugin.ts
@@ -47,14 +47,27 @@ export class LernaPackagesPlugin extends ConverterComponent {
             throw new Error('No lerna.json found or packages defined.');
         }
 
-        for (const packageGlob of packages) {
+        for (let packageGlob of packages) {
+            if(packageGlob.endsWith('**')){
+                //only search for directories
+                packageGlob = packageGlob + '/';
+            }
             const thisPkgs = glob.sync(packageGlob, {
-                ignore: ['node_modules']
+                ignore: ['**/node_modules/**']
             });
 
             for (const pkg of thisPkgs) {
-                const pkgConfig = JSON.parse(fs.readFileSync(join(pkg, 'package.json'), 'utf8'));
-                this.lernaPackages[pkgConfig['name']] = pkg;
+                try{
+                    const pkgConfig = JSON.parse(fs.readFileSync(join(pkg, 'package.json'), 'utf8'));
+                    this.lernaPackages[pkgConfig['name']] = pkg;
+                }
+                catch(err){
+                    if(err.code === 'ENOENT' && packageGlob.endsWith('**/')){
+                        console.warn(`Direcotry "${pkg}" had no package.json but package glob ends with ** so ignoring`);
+                        continue;
+                    }
+                    throw err;
+                }
             }
         }
 

--- a/plugin.ts
+++ b/plugin.ts
@@ -130,6 +130,8 @@ export class LernaPackagesPlugin extends ConverterComponent {
             // console.log('lernaPackageModules[lernaPackageName]', lernaPackageModules[lernaPackageName]);
             if (child.kindOf(ReflectionKind.ExternalModule) || child.kindOf(ReflectionKind.Module)) {
                 console.log(`put ${child.name} stuff into ${lernaPackageName}`);
+                const projectFileEntry = Object.entries(context.project.reflections).find(([key,value]) => value.name === child.name ? key : null);
+                delete context.project.reflections[projectFileEntry[0]];
                 if (child.children) {
                     for (const cc of child.children) {
                         lernaPackageModules[lernaPackageName].children.push(cc);

--- a/plugin.ts
+++ b/plugin.ts
@@ -47,27 +47,14 @@ export class LernaPackagesPlugin extends ConverterComponent {
             throw new Error('No lerna.json found or packages defined.');
         }
 
-        for (let packageGlob of packages) {
-            if(packageGlob.endsWith('**')){
-                //only search for directories
-                packageGlob = packageGlob + '/';
-            }
+        for (const packageGlob of packages) {
             const thisPkgs = glob.sync(packageGlob, {
-                ignore: ['**/node_modules/**']
+                ignore: ['node_modules']
             });
 
             for (const pkg of thisPkgs) {
-                try{
-                    const pkgConfig = JSON.parse(fs.readFileSync(join(pkg, 'package.json'), 'utf8'));
-                    this.lernaPackages[pkgConfig['name']] = pkg;
-                }
-                catch(err){
-                    if(err.code === 'ENOENT' && packageGlob.endsWith('**/')){
-                        console.warn(`Direcotry "${pkg}" had no package.json but package glob ends with ** so ignoring`);
-                        continue;
-                    }
-                    throw err;
-                }
+                const pkgConfig = JSON.parse(fs.readFileSync(join(pkg, 'package.json'), 'utf8'));
+                this.lernaPackages[pkgConfig['name']] = pkg;
             }
         }
 


### PR DESCRIPTION
ISSUES CLOSED: #10

This change updates the code to  look through the list of `project.reflections` for the `child` reflection that we are adding information too and removes it to prevent a duplicate declaration.