### PR TITLE
allow for workspaces being a map that contains packages

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -40,7 +40,7 @@ export class LernaPackagesPlugin extends ConverterComponent {
             packages = lernaConfig.packages;
         } else if (lernaConfig.useWorkspaces) {
             const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-            packages = packageJson.workspaces;
+            packages = packageJson.workspaces.packages || packageJson.workspaces;
         }
 
         if (!packages || packages.length === 0) {


### PR DESCRIPTION
Thanks for making this plugin! I'd very much like to make it work for some [largish](https://github.com/jupyterlab/jupyterlab/blob/master/package.json) projects, as well as getting it working with [sphinx-js](https://github.com/mozilla/sphinx-js#typescript-support).

It looks like lerna can expect `workspaces` in `package.json` to be a map with the key `packages`:

https://github.com/lerna/lerna/blob/86017d769bb83dfd1abb88f4cf560f73651ad494/core/project/index.js#L87

This PR adopts the same approach. I've applied it locally, and have yet to make it actually work, but this seemed like a good first step forward!