### PR TITLE
handle glob matches that aren't packages

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -53,8 +53,10 @@ export class LernaPackagesPlugin extends ConverterComponent {
             });
 
             for (const pkg of thisPkgs) {
-                const pkgConfig = JSON.parse(fs.readFileSync(join(pkg, 'package.json'), 'utf8'));
-                this.lernaPackages[pkgConfig['name']] = pkg;
+                if(fs.existsSync(join(pkg, 'package.json'))) {
+                    const pkgConfig = JSON.parse(fs.readFileSync(join(pkg, 'package.json'), 'utf8'));
+                    this.lernaPackages[pkgConfig['name']] = pkg;
+                }
             }
         }
 


### PR DESCRIPTION
Follow-on to #12.

Sometimes, the package matching glob can match things which aren't directories containing a `package.json`. This checks such a file exists before trying to read it.