### PR TITLE
Render typedoc when there is only a readme and no documented code

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -147,7 +147,7 @@ export class LernaPackagesPlugin extends ConverterComponent {
                 continue;
             }
 
-            if (lernaPackageModules[i].children && lernaPackageModules[i].children.length > 0) {
+            if (lernaPackageModules[i].hasComment() || lernaPackageModules[i].children && lernaPackageModules[i].children.length > 0) {
                 context.project.children.push(lernaPackageModules[i]);
                 context.registerReflection(lernaPackageModules[i]);
             }


### PR DESCRIPTION
This allows to include packages that do not have any documented functions but a readme. Ignoring should happen through the exclude entry.