### PR TITLE
chore: repo and dist cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
-plugin.js
-index.js
-*.js.map
+dist
+*.tsbuildinfo

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-node_modules

--- a/README.md
+++ b/README.md
@@ -12,26 +12,24 @@ Example source code: https://github.com/marcj/marshal.ts
 
 Just install it and type `typedoc`:
 
-```
-npm i -D typedoc-plugin-lerna-packages typedoc@^0.15
+```bash
+npm i -D typedoc-plugin-lerna-packages typedoc@~0.16
+# yarn add -D typedoc-plugin-lerna-packages typedoc@0.16 --tilde
 
-./node_modules/.bin/typedoc
+npx typedoc
+# yarn typedoc
 ```
-
 
 Example `typedoc.js` in your root folder
 
-```
+```js
 module.exports = {
-    "mode": "modules",
-    "out": "docs",
-    exclude: [
-        '**/node_modules/**',
-        '**/*.spec.ts',
-    ],
-    name: 'MY NAME',
-    excludePrivate: true,
-    skipInternal: true
+  mode: 'modules',
+  out: 'docs',
+  exclude: ['**/node_modules/**', '**/*.spec.ts'],
+  name: 'MY NAME',
+  excludePrivate: true,
+  skipInternal: true
 };
 ```
 
@@ -39,14 +37,13 @@ module.exports = {
 
 In `typedoc.js` you can add following extra config values to change the behavior of this plugin.
 
-```
+```js
 module.exports = {
-    //...
-    
-    //exclude packages from being generated
-    lernaExclude: ['@vendor/integration-tests', '@vendor/examples'],
-};
+  //...
 
+  //exclude packages from being generated
+  lernaExclude: ['@vendor/integration-tests', '@vendor/examples']
+};
 ```
 
 ### Development

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,23 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
+    },
+    "@types/glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "dev": true,
+      "requires": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -11,9 +28,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.7.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.4.tgz",
-      "integrity": "sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ==",
+      "version": "13.1.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.8.tgz",
+      "integrity": "sha512-6XzyyNM9EKQW4HKuzbo/CkOIjn/evtCmsU+MUM1xDfJ+3/rNjBttM1NgN7AOQvN6tP1Sl1D1PIKMreTArnxM9A==",
       "dev": true
     },
     "backbone": {

--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
   "name": "typedoc-plugin-lerna-packages",
   "version": "0.2.1",
   "description": "Display Typescript documentation for Lerna monorepo with the correct module exports.",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "prepare": "tsc",
-    "prepublishOnly": "tsc"
+    "prepare": "tsc"
   },
   "keywords": [
     "typedocplugin",
-    "typedoc"
+    "typedoc",
+    "lerna"
   ],
   "repository": {
     "type": "git",
@@ -19,11 +19,15 @@
   "author": "Marc J. Schmidt <marc@marcjschmidt.de>",
   "license": "MIT",
   "peerDependencies": {
-    "typedoc": "^0.16.4"
+    "typedoc": "^0.16.7"
   },
   "devDependencies": {
-    "@types/node": "^12.7.4",
+    "@types/glob": "^7.1.1",
+    "@types/node": "^13.1.8",
     "typedoc": "^0.16.7",
     "typescript": "^3.7.5"
-  }
+  },
+  "files": [
+    "dist"
+  ]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { LernaPackagesPlugin } from './plugin'
+import { LernaPackagesPlugin } from './plugin';
 import { PluginHost } from 'typedoc/dist/lib/utils';
 import { ParameterType } from 'typedoc';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,17 @@
 {
   "compilerOptions": {
+    "rootDir": "src",
     "moduleResolution": "node",
-    "allowJs": true,
     "module": "commonjs",
-    "target": "es2015",
+    "target": "es6",
     "sourceMap": true,
     "downlevelIteration": true,
     "inlineSources": true,
-    "outDir": "./",
+    "outDir": "./dist",
     "experimentalDecorators": true,
-    "lib": [
-      "es5",
-      "es2015.core",
-      "es2015.collection",
-      "es2015.iterable",
-      "es2016.array.include" // Supported by Node 6+
-    ],
-    "typeRoots": ["node_modules/@types"]
+    "emitDecoratorMetadata": true,
+    "incremental": true,
+    "lib": ["es6"]
   },
-  "files": [
-    "index.ts",
-    "plugin.ts"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
I guess you could've seen this one coming a mile away then.

Putting it in scope here as well as opening the discussion as to which changes and issue you disagree with so I can address them.

As for the "cleaner dist" part lets put some before and after in here.

**before (current)**:

```
npm notice 📦  typedoc-plugin-lerna-packages@0.2.1
npm notice === Tarball Contents ===
npm notice 1.1kB  LICENSE
npm notice 720B   index.js
npm notice 7.0kB  plugin.js
npm notice 690B   package.json
npm notice 522B   tsconfig.json
npm notice 1.2kB  index.js.map
npm notice 11.1kB plugin.js.map
npm notice 1.4kB  README.md
npm notice 648B   index.ts
npm notice 6.2kB  plugin.ts
npm notice === Tarball Details ===
npm notice name:          typedoc-plugin-lerna-packages
npm notice version:       0.2.1
npm notice package size:  7.2 kB
npm notice unpacked size: 30.5 kB
npm notice shasum:        e488ce38f4f112fe8c5a376060db6505d55b1148
npm notice integrity:     sha512-tNMrK0ucl6Vwd[...]2koZfC6wn/M1w==
npm notice total files:   10
```

**after merge**:
```
npm notice 📦  typedoc-plugin-lerna-packages@0.2.1
npm notice === Tarball Contents ===
npm notice 1.1kB LICENSE
npm notice 720B  dist/index.js
npm notice 7.5kB dist/plugin.js
npm notice 737B  package.json
npm notice 561B  dist/index.js.map
npm notice 4.7kB dist/plugin.js.map
npm notice 1.4kB README.md
npm notice === Tarball Details ===
npm notice name:          typedoc-plugin-lerna-packages
npm notice version:       0.2.1
npm notice package size:  5.7 kB
npm notice unpacked size: 16.6 kB
npm notice shasum:        903afc2fe525c4ca0aad58186e716c839366c41c
npm notice integrity:     sha512-npo2gt7m6WG4v[...]4P4osGgG+Nkrg==
npm notice total files:   7
```

Notice how right now `index.ts` and `plugin.ts` (and `tsconfig.json`) are getting published to NPM. This is unnecessary (they aren't used by TS at any given time, not even when people would try to extend the plugin for which they'd need `.d.ts` files instead) and just bloats up the bundle size. 

---

If one of the things you "don't agree with" are having the `src` directory then that for sure is a change I can easily revert. Other than that let me address the changes

- Using `files` field in package.json means specifying which files to publish rather than which files to ignore through `.npmignore`. The files-to-publish list is generally static in TS based projects (`dist` + whatever NPM auto-adds) while the list of files to ignore can greatly fluctuate. In order to not have to continually keep updating .npmignore it is therefore much better to specify the files through the `files` field.
- Putting the output files in `dist` allows for the above as well as a clean working directory when developing
- Using incremental builds in TS (`incremental: true` flag) enormously speeds up consecutive builds
- lib and target in tsc can be set to es6 since there are no NodeJS versions that are still being supported that do not also support ES6 ([NodeJS 8.x has gone End Of Life as of 31st of December 2019, see release history and schedule here](https://github.com/nodejs/Release))
- setting the `rootDir` in tsconfig allows for a cleaner publish, see samples above.
- `prepare` and `prepublishOnly` script both run on `npm publish` so `tsc` was ran twice. `prepare` also runs after `npm install`. I kept only `prepare` so when publishing `tsc` is only ran once, while it also still runs after `npm install`.
  - personally I'd argue for only keeping `prepublishOnly` but this is your call
- Added `@types/glob` because TS was complaining that it was missing
  - It would do so especially if strict mode would get enabled, I didn't for now but it should be considered
- The changed imports to `fs` and `glob` are for micro-performance increases. Rather than importing the whole libraries, the plugin now only imports the specific functions. Every bit of micro-performance boost is always good IMHO.