### PR TITLE
fix(plugin.ts): return early if project.children is undefined

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -60,6 +60,9 @@ export class LernaPackagesPlugin extends ConverterComponent {
         console.log('Lerna packages found', this.lernaPackages);
         const lernaPackageModules: { [lernaPackageName: string]: DeclarationReflection } = {};
 
+        // children could be undefined if there are some TS errors in the files
+        if (!context.project.children) return;
+
         const copyChildren = context.project.children.slice(0);
 
         const cwd = process.cwd();


### PR DESCRIPTION
Should fix #21, I found if there are some TS errors in my files, it causes the `Cannot read property 'slice' of undefined` error. And if typedoc crashes at that point, it could not print the TS errors.

**Before:**

<img width="806" alt="截圖 2020-06-29 下午7 45 57" src="https://user-images.githubusercontent.com/3382565/86001308-4c105200-ba41-11ea-88b0-d24ad52e2bf7.png">

**After:**

<img width="804" alt="截圖 2020-06-29 下午7 46 16" src="https://user-images.githubusercontent.com/3382565/86001278-40249000-ba41-11ea-9b78-0e668184625b.png">
