### PR TITLE
fix: readme path not correctly expanded

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -112,7 +112,7 @@ export class LernaPackagesPlugin extends ConverterComponent {
 
             const readMePath = join(fullPath, this.readme ?? 'README.md');
 
-            if (this.readme !== 'none' && existsSync(readMePath)) {
+            if (this.readme && this.readme !== 'none' && existsSync(readMePath)) {
                 let readme = readFileSync(readMePath);
                 reflection.comment = new Comment('', readme.toString());
             }


### PR DESCRIPTION
When not specifiying a readme config property, the readme path is set to the directory of the lerna package
Before, it was only checked if the readme is not none but as lerna sets the property to `''` when no config is set, the check becomes truthy and the plugin tries to read the directory.
Added a check if `this.readme` is truthy to solve this issue, as `''` is falsy.

Fixes #29 